### PR TITLE
Fixes some errors in structure checker, prevents it from failing on c…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    simplecov (0.10.0)
+    simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
@@ -71,6 +71,3 @@ DEPENDENCIES
   codeclimate-test-reporter
   corundum
   xing-root!
-
-BUNDLED WITH
-   1.11.2

--- a/lib/xing/edicts/structure-checker.rb
+++ b/lib/xing/edicts/structure-checker.rb
@@ -51,7 +51,8 @@ module Xing::Edicts
           problems.each{|prob| out_stream.puts "  " + prob.to_s}
           out_stream.puts
         end
-        raise Error, "Problems found in ECMAScript structure"
+        out_stream.puts "Problems found in ECMAScript structure"
+        #raise Error, "Problems found in ECMAScript structure"
       end
     end
 

--- a/lib/xing/utils/import_checker.rb
+++ b/lib/xing/utils/import_checker.rb
@@ -13,7 +13,7 @@ module Xing::Utils
     end
 
     def is_import_line
-      /\s*import/.match(@import_line)
+      /^\s*import/.match(@import_line)
     end
 
     def skip_to_end_of_import
@@ -34,7 +34,12 @@ module Xing::Utils
     end
 
     def check_empty_match
-      problem "doesn't seem to have a 'from' clause..." if @md.nil?
+      if @md.nil?
+        problem "doesn't seem to have a 'from' clause..."
+        true
+      else
+        false
+      end
     end
 
     def check_structure
@@ -60,16 +65,18 @@ module Xing::Utils
     end
 
     def check(&error_block)
-      initialize_check(error_block)
-      while @lineno < @lines.length
-        read_next
-        if is_import_line
-          skip_to_end_of_import
-          match_line
-          check_empty_match
-          check_structure
+      begin
+        initialize_check(error_block)
+        while @lineno < @lines.length
+          read_next
+          if is_import_line
+            skip_to_end_of_import
+            match_line
+            check_structure if !check_empty_match
+          end
+          @lineno += 1
         end
-        @lineno += 1
+      rescue
       end
     end
   end

--- a/spec/edicts/structure_checker_spec.rb
+++ b/spec/edicts/structure_checker_spec.rb
@@ -22,7 +22,9 @@ describe Xing::Edicts::StructureChecker do
     end
 
     it "should report errors" do
-      expect{subject.action}.to raise_error(Xing::Edicts::StructureChecker::Error)
+      subject.action
+      #expect{subject.action}.to raise_error(Xing::Edicts::StructureChecker::Error)
+      expect(stdout.string).to match("Problems found in ECMAScript structure")
       expect(stdout.string).to match(%r{In test-dir/problem.js})
       expect(stdout.string).to match(%r{'from' includes ../})
     end
@@ -35,6 +37,7 @@ describe Xing::Edicts::StructureChecker do
 
     it "should not report errors" do
       expect{subject.action}.not_to raise_error
+      expect(stdout.string).to be_empty
     end
   end
 


### PR DESCRIPTION
…ode errors, makes it not stop the build process

So, I was trying to get setup a resources file in xing-app-base and I found the structure checker was erroring out when I ran rake spec:full. I eventually traced it back to a comment that began: // import

I decided to do three things:
1. Fix the issue in the structure checker
2. Prevent the structure checker from erroring out due to Ruby exceptions (as opposed to issues raised by the checker itself) cause a Ruby exception prevented me from seeing the actual cause of the problem
3. Convert the structure checker to not interrupt the build process on errors and instead just output warnings -- it seems as this is going out into the world, we want to provide conventions, but not enforce those conventions so strongly the program won't even run without them.
