### PR TITLE
Initialize task

### DIFF
--- a/lib/xing/tasks/backend.rb
+++ b/lib/xing/tasks/backend.rb
@@ -18,6 +18,12 @@ module Xing
           end
           task :check_dependencies => :bundle_install
 
+          desc "Initialize database"
+          edict_task :db_create, Edicts::CleanRun do |dm|
+            dm.shell_cmd = %w{bundle exec rake db:create}
+          end
+          task :db_create => :bundle_install
+
           desc "Migrate database up to current"
           edict_task :db_migrate, Edicts::CleanRun do |dm|
             dm.shell_cmd = %w{bundle exec rake db:migrate}
@@ -36,6 +42,8 @@ module Xing
             ap.shell_cmd = %w{bundle exec rake assets:precompile}
           end
           task :assets_precompile => [:bundle_install, :db_migrate]
+
+          task :initialize => [:db_create, :db_seed]
 
           task :all => [:db_seed, :assets_precompile]
         end

--- a/lib/xing/tasks/initialize.rb
+++ b/lib/xing/tasks/initialize.rb
@@ -1,0 +1,17 @@
+require 'xing/edicts'
+require 'xing/tasks/tasklib'
+
+module Xing
+  module Tasks
+    class Initialize < Tasklib
+      default_namespace :initialize
+
+      def define
+        in_namespace do
+          task :all => ["backend:initialize"]
+        end
+      end
+
+    end
+  end
+end

--- a/spec/tasks/backend_spec.rb
+++ b/spec/tasks/backend_spec.rb
@@ -12,10 +12,12 @@ describe Xing::Tasks::Backend do
   it "creates all the backend rake tasks" do
     expect(Rake.application.lookup "backend:bundle_install").to be_a(Rake::Task)
     expect(Rake.application.lookup "backend:check_dependencies").to be_a(Rake::Task)
+    expect(Rake.application.lookup "backend:db_create").to be_a(Rake::Task)
     expect(Rake.application.lookup "backend:db_migrate").to be_a(Rake::Task)
     expect(Rake.application.lookup "backend:setup").to be_a(Rake::Task)
     expect(Rake.application.lookup "backend:db_seed").to be_a(Rake::Task)
     expect(Rake.application.lookup "backend:assets_precompile").to be_a(Rake::Task)
+    expect(Rake.application.lookup "backend:initialize").to be_a(Rake::Task)
     expect(Rake.application.lookup "backend:all").to be_a(Rake::Task)
   end
 

--- a/spec/tasks/initialize_spec.rb
+++ b/spec/tasks/initialize_spec.rb
@@ -1,0 +1,17 @@
+require 'xing/tasks/initialize'
+
+
+describe Xing::Tasks::Initialize do
+  before :each do
+    Rake.application = nil
+    Xing::Tasks::Initialize.new
+  end
+
+  it "creates rake tasks" do
+    expect(Rake.application.lookup "initialize:all").to be_a(Rake::Task)
+  end
+
+  after :each do
+    Rake.application = nil
+  end
+end

--- a/xing-root.gemspec
+++ b/xing-root.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
     lib/xing/tasks/tasklib.rb
     lib/xing/tasks/spec.rb
     lib/xing/tasks/develop.rb
+    lib/xing/tasks/initialize.rb
     lib/xing/managers/child.rb
     lib/xing/managers/tmux.rb
     lib/xing/edicts/start-child.rb
@@ -39,6 +40,7 @@ Gem::Specification.new do |spec|
     lib/xing-root.rb
     spec/tasks/frontend_spec.rb
     spec/tasks/develop_spec.rb
+    spec/tasks/initialize_spec.rb
     spec/managers/tmux_spec.rb
     spec/support/file-sandbox.rb
     spec/edicts/start-child_spec.rb


### PR DESCRIPTION
Adds an initialize tasklib for setting up the database. Arguably this could be part of xing new... but running a database creation command in a code generation task seems a bit odd to me.

seems better to have:
xing new...
rake initialize
rake develop?

alternatively these could be part of rake develop on its first run?
