### PR TITLE
Adds configs to rake develop

### DIFF
--- a/lib/xing/tasks/develop.rb
+++ b/lib/xing/tasks/develop.rb
@@ -32,7 +32,7 @@ module Xing
         begin
           require 'xing/managers/child'
           require 'xing/managers/tmux'
-          if Managers::Tmux.available?
+          if output_manager == :tmux and Managers::Tmux.available?
             Managers::TmuxPane.new
           else
             ChildManager.new


### PR DESCRIPTION
By passing a block to Xing::Tasks::Develop.new, you can configure the task

Of note: dev.enabled_services is an array of symbols - deleting symbols or
setting the array wholesale allows you to control what `rake develop` will boot. So e.g.

```
Xing::Tasks::Develop.new do |dev|
  dev.enabled_services.delete(:sidekiq)
end
```

is sufficient to disable the sidekiq server.

Also included:

```
  dev.output_manager = :child
```

will switch from the default tmux manager to interleaved children, if you prefer that.
